### PR TITLE
Skip simulateContract for token approval

### DIFF
--- a/packages/pancake-liquidity-widgets/src/components/Preview/index.tsx
+++ b/packages/pancake-liquidity-widgets/src/components/Preview/index.tsx
@@ -21,6 +21,7 @@ import { BASE_BPS, NetworkInfo } from "../../constants";
 import { useWeb3Provider } from "../../hooks/useProvider";
 import {
   PI_LEVEL,
+  calculateGasMargin,
   formatCurrency,
   formatNumber,
   formatWei,
@@ -56,15 +57,6 @@ export interface PreviewProps {
   zapState: ZapState;
   onDismiss: () => void;
   onTxSubmit?: (tx: string) => void;
-}
-
-function calculateGasMargin(value: bigint): bigint {
-  const defaultGasLimitMargin = BigInt(20_000);
-  const gasMargin = (value * BigInt(2000)) / BigInt(10000);
-
-  return gasMargin >= defaultGasLimitMargin
-    ? value + gasMargin
-    : value + defaultGasLimitMargin;
 }
 
 export default function Preview({

--- a/packages/pancake-liquidity-widgets/src/utils/index.ts
+++ b/packages/pancake-liquidity-widgets/src/utils/index.ts
@@ -263,3 +263,12 @@ export const getWarningThreshold = (zapFee: ProtocolFeeAction) => {
   if (zapFee.protocolFee.pcm <= feeConfig[PairType.Correlated]) return 0.25;
   return 1;
 };
+
+export function calculateGasMargin(value: bigint): bigint {
+  const defaultGasLimitMargin = BigInt(20_000);
+  const gasMargin = (value * BigInt(2000)) / BigInt(10000);
+
+  return gasMargin >= defaultGasLimitMargin
+    ? value + gasMargin
+    : value + defaultGasLimitMargin;
+}


### PR DESCRIPTION
USDT on Ethereum has different ABI of approve function which results in successful gas estimation but simulateContract failed